### PR TITLE
Update collect command to include filter

### DIFF
--- a/docs/learn.md
+++ b/docs/learn.md
@@ -80,7 +80,7 @@ Create a file, e.g. `~/.tailpipe/config/aws.tpc`, with a `connection` and `parti
 Now let's collect the logs:
 
 ```bash
-tailpipe collect aws_cloudtrail_log
+tailpipe collect aws_cloudtrail_log  --from 2016-01-01
 ```
 
 

--- a/docs/learn.md
+++ b/docs/learn.md
@@ -114,7 +114,7 @@ or find the oldest and newest records:
 select 
   min(tp_date), max(tp_date)
 from 
-  aws_cloudtrail_log"
+  aws_cloudtrail_log
 ```
 
 This query finds the top 10 IPs:
@@ -125,7 +125,7 @@ select
 from
    aws_cloudtrail_log
 group by
-  tp_source_ip order by count desc"
+  tp_source_ip order by count desc
 ```
 
 This query lists Cloudtrail event types for a specified day:
@@ -136,7 +136,7 @@ select distinct
 from 
   aws_cloudtrail_log
 where 
-  tp_date = '2024-11-07'"
+  tp_date = '2024-11-07'
 ```
 
 Because we specified `tp_date = '2024-11-07'`, Tailpipe only needs to read one of many files created by the collection process. 


### PR DESCRIPTION
When using the `collect` command as written, tailpipe results similar to this:
```
Artifacts:
  Discovered: 20
  Downloaded: 19 232MB
  Extracted:  19

Rows:
  Received: 1,839,207
  Enriched: 1,839,207
  Saved:            0
  Filtered: 1,839,207

Files:
  No files to compact.
```

The screenshot gives an example using the filter, but the example command doesn't :)

Additionally, fixes a couple instances of stray `"` that cause errors