### PR TITLE
Trigger Algolia search update on docs deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
   workflow_dispatch:
+
+permissions: {}
+
 jobs:
   trigger-vercel-deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,3 +12,13 @@ jobs:
       - name: Trigger Vercel deploy
         run: |
           curl -X POST ${{ secrets.VERCEL_DEPLOY_LINK_PROD }}
+
+  update-search-records:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger search records update in tailpipe.io
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.G_PERSONAL_ACCESS_TOKEN }}
+          repository: turbot/tailpipe.io
+          event-type: update-search-records


### PR DESCRIPTION
## Summary
- Add `repository_dispatch` to `deploy.yml` that triggers `update-search-records` workflow in turbot/tailpipe.io when docs are pushed to main

## Context
Previously, Algolia search records were re-uploaded on every site deploy (even when docs hadn't changed). This decouples search updates so they only happen when docs actually change.

## Companion PR
- https://github.com/turbot/tailpipe.io/pull/120

## Test plan
- [ ] Merge companion PR in tailpipe.io first (adds the receiving workflow)
- [ ] Push docs change to main and verify `update-search-records` workflow triggers in tailpipe.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)